### PR TITLE
Rewrite in Kotlin & Drops HttpClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>alchemy-http</artifactId>
-            <version>2.1-kotlin</version>
+            <version>3.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>alchemy-http-mock</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.1-kotlin</version>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
 
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>alchemy-http</artifactId>
-            <version>2.0</version>
+            <version>2.1-kotlin</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>alchemy-http-mock</artifactId>
-    <version>2.1-kotlin</version>
+    <version>3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,12 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>alchemy-collections</artifactId>
+            <version>2.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>alchemy-generator</artifactId>
             <version>2.2</version>
             <scope>test</scope>

--- a/src/main/java/tech/sirwellington/alchemy/http/mock/MockAlchemyHttp.java
+++ b/src/main/java/tech/sirwellington/alchemy/http/mock/MockAlchemyHttp.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sir.wellington.alchemy.collections.lists.Lists;
 import tech.sirwellington.alchemy.annotations.access.Internal;
+import tech.sirwellington.alchemy.annotations.arguments.Required;
 import tech.sirwellington.alchemy.annotations.designs.StepMachineDesign;
 import tech.sirwellington.alchemy.arguments.AlchemyAssertion;
 import tech.sirwellington.alchemy.arguments.assertions.Assertions;
@@ -62,12 +63,14 @@ class MockAlchemyHttp implements AlchemyHttp
         this.expectedActions.putAll(expectedActions);
     }
 
+    @Required
     @Override
     public AlchemyHttp usingDefaultHeader(String key, String value)
     {
         return this;
     }
 
+    @Required
     @Override
     public Map<String, String> getDefaultHeaders()
     {

--- a/src/main/java/tech/sirwellington/alchemy/http/mock/MockAlchemyHttp.java
+++ b/src/main/java/tech/sirwellington/alchemy/http/mock/MockAlchemyHttp.java
@@ -75,7 +75,7 @@ class MockAlchemyHttp implements AlchemyHttp
     }
 
     @Override
-    public AlchemyRequest.Step1 go()
+    public AlchemyRequestSteps.Step1 go()
     {
         return new MockSteps.MockStep1(this);
     }

--- a/src/main/java/tech/sirwellington/alchemy/http/mock/MockSteps.java
+++ b/src/main/java/tech/sirwellington/alchemy/http/mock/MockSteps.java
@@ -16,23 +16,25 @@
 
 package tech.sirwellington.alchemy.http.mock;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import kotlin.io.ByteStreamsKt;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tech.sirwellington.alchemy.annotations.access.NonInstantiable;
 import tech.sirwellington.alchemy.annotations.designs.StepMachineDesign;
-import tech.sirwellington.alchemy.arguments.assertions.NetworkAssertions;
 import tech.sirwellington.alchemy.http.AlchemyRequest;
 import tech.sirwellington.alchemy.http.HttpResponse;
 import tech.sirwellington.alchemy.http.exceptions.AlchemyHttpException;
+import tech.sirwellington.alchemy.http.exceptions.OperationFailedException;
 
 import static tech.sirwellington.alchemy.annotations.designs.StepMachineDesign.Role.STEP;
 import static tech.sirwellington.alchemy.arguments.Arguments.*;
 import static tech.sirwellington.alchemy.arguments.assertions.Assertions.notNull;
-import static tech.sirwellington.alchemy.arguments.assertions.NetworkAssertions.*;
+import static tech.sirwellington.alchemy.arguments.assertions.NetworkAssertions.validURL;
 import static tech.sirwellington.alchemy.arguments.assertions.StringAssertions.*;
 import static tech.sirwellington.alchemy.http.mock.MockRequest.NO_BODY;
 
@@ -100,7 +102,28 @@ final class MockSteps
         @Override
         public byte[] download(URL url) throws IllegalArgumentException, AlchemyHttpException
         {
-            return null;
+            try
+            {
+                return ByteStreamsKt.readBytes(url.openStream(), 1024 * 4);
+            }
+            catch (IOException ex)
+            {
+                throw new OperationFailedException(ex);
+            }
+        }
+
+        @NotNull
+        @Override
+        public byte[] download(String s) throws IllegalArgumentException
+        {
+            try
+            {
+                return download(new URL(s));
+            }
+            catch (MalformedURLException ex)
+            {
+                throw new IllegalArgumentException(ex);
+            }
         }
     }
 

--- a/src/main/java/tech/sirwellington/alchemy/http/mock/MockSteps.java
+++ b/src/main/java/tech/sirwellington/alchemy/http/mock/MockSteps.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tech.sirwellington.alchemy.annotations.access.NonInstantiable;
 import tech.sirwellington.alchemy.annotations.designs.StepMachineDesign;
-import tech.sirwellington.alchemy.http.AlchemyRequest;
+import tech.sirwellington.alchemy.http.AlchemyRequestSteps;
 import tech.sirwellington.alchemy.http.HttpResponse;
 import tech.sirwellington.alchemy.http.exceptions.AlchemyHttpException;
 import tech.sirwellington.alchemy.http.exceptions.OperationFailedException;
@@ -54,7 +54,7 @@ final class MockSteps
     }
 
     @StepMachineDesign(role = STEP)
-    static class MockStep1 implements AlchemyRequest.Step1
+    static class MockStep1 implements AlchemyRequestSteps.Step1
     {
 
         final MockAlchemyHttp mockHttp;
@@ -68,14 +68,14 @@ final class MockSteps
         }
 
         @Override
-        public AlchemyRequest.Step3 get()
+        public AlchemyRequestSteps.Step3 get()
         {
             request.method = MockRequest.Method.GET;
             return new MockStep3(mockHttp, request);
         }
 
         @Override
-        public AlchemyRequest.Step2 post()
+        public AlchemyRequestSteps.Step2 post()
         {
             request.method = MockRequest.Method.POST;
 
@@ -83,7 +83,7 @@ final class MockSteps
         }
 
         @Override
-        public AlchemyRequest.Step2 put()
+        public AlchemyRequestSteps.Step2 put()
         {
             request.method = MockRequest.Method.PUT;
 
@@ -91,7 +91,7 @@ final class MockSteps
         }
 
         @Override
-        public AlchemyRequest.Step2 delete()
+        public AlchemyRequestSteps.Step2 delete()
         {
             request.method = MockRequest.Method.DELETE;
 
@@ -128,7 +128,7 @@ final class MockSteps
     }
 
     @StepMachineDesign(role = STEP)
-    static class MockStep2 implements AlchemyRequest.Step2
+    static class MockStep2 implements AlchemyRequestSteps.Step2
     {
 
         MockAlchemyHttp mockAlchemyHttp;
@@ -144,7 +144,7 @@ final class MockSteps
         }
 
         @Override
-        public AlchemyRequest.Step3 nothing()
+        public AlchemyRequestSteps.Step3 nothing()
         {
             request.body = NO_BODY;
 
@@ -152,7 +152,7 @@ final class MockSteps
         }
 
         @Override
-        public AlchemyRequest.Step3 body(String jsonString) throws IllegalArgumentException
+        public AlchemyRequestSteps.Step3 body(String jsonString) throws IllegalArgumentException
         {
             checkThat(jsonString)
                 .usingMessage("jsonString cannot be empty")
@@ -164,7 +164,7 @@ final class MockSteps
         }
 
         @Override
-        public AlchemyRequest.Step3 body(Object pojo) throws IllegalArgumentException
+        public AlchemyRequestSteps.Step3 body(Object pojo) throws IllegalArgumentException
         {
             request.body = pojo;
 
@@ -174,7 +174,7 @@ final class MockSteps
     }
 
     @StepMachineDesign(role = STEP)
-    static class MockStep3 implements AlchemyRequest.Step3
+    static class MockStep3 implements AlchemyRequestSteps.Step3
     {
 
         final MockAlchemyHttp mockAlchemyHttp;
@@ -191,7 +191,7 @@ final class MockSteps
 
         @NotNull
         @Override
-        public AlchemyRequest.Step3 accept(String first, String... others) throws IllegalArgumentException
+        public AlchemyRequestSteps.Step3 accept(String first, String... others) throws IllegalArgumentException
         {
             String tail = String.join(", ", others);
             String header = String.join(", ", first, tail);
@@ -201,21 +201,21 @@ final class MockSteps
 
         @NotNull
         @Override
-        public AlchemyRequest.Step3 usingQueryParam(String s, Number number) throws IllegalArgumentException
+        public AlchemyRequestSteps.Step3 usingQueryParam(String s, Number number) throws IllegalArgumentException
         {
             return usingQueryParam(s, number.toString());
         }
 
         @NotNull
         @Override
-        public AlchemyRequest.Step3 usingQueryParam(String s, boolean b) throws IllegalArgumentException
+        public AlchemyRequestSteps.Step3 usingQueryParam(String s, boolean b) throws IllegalArgumentException
         {
             return this;
         }
 
         @NotNull
         @Override
-        public AlchemyRequest.Step3 followRedirects()
+        public AlchemyRequestSteps.Step3 followRedirects()
         {
             return this;
         }
@@ -228,19 +228,19 @@ final class MockSteps
         }
 
         @Override
-        public AlchemyRequest.Step3 usingHeader(String key, String value) throws IllegalArgumentException
+        public AlchemyRequestSteps.Step3 usingHeader(String key, String value) throws IllegalArgumentException
         {
             return this;
         }
 
         @Override
-        public AlchemyRequest.Step3 usingQueryParam(String name, String value) throws IllegalArgumentException
+        public AlchemyRequestSteps.Step3 usingQueryParam(String name, String value) throws IllegalArgumentException
         {
             return this;
         }
 
         @Override
-        public AlchemyRequest.Step3 followRedirects(int maxNumberOfTimes) throws IllegalArgumentException
+        public AlchemyRequestSteps.Step3 followRedirects(int maxNumberOfTimes) throws IllegalArgumentException
         {
             return this;
         }
@@ -258,7 +258,7 @@ final class MockSteps
 
         @NotNull
         @Override
-        public AlchemyRequest.Step5<HttpResponse> onSuccess(AlchemyRequest.OnSuccess<HttpResponse> onSuccess)
+        public AlchemyRequestSteps.Step5<HttpResponse> onSuccess(AlchemyRequestSteps.OnSuccess<HttpResponse> onSuccess)
         {
             checkThat(onSuccess)
                     .usingMessage("Callback cannot be null")
@@ -269,7 +269,7 @@ final class MockSteps
         }
 
         @Override
-        public <ResponseType> AlchemyRequest.Step4<ResponseType> expecting(Class<ResponseType> classOfResponseType) throws
+        public <ResponseType> AlchemyRequestSteps.Step4<ResponseType> expecting(Class<ResponseType> classOfResponseType) throws
             IllegalArgumentException
         {
             return new MockStep4<>(mockAlchemyHttp, this.request, classOfResponseType);
@@ -278,7 +278,7 @@ final class MockSteps
     }
 
     @StepMachineDesign(role = STEP)
-    static class MockStep4<R> implements AlchemyRequest.Step4<R>
+    static class MockStep4<R> implements AlchemyRequestSteps.Step4<R>
     {
 
         final MockAlchemyHttp mockAlchemyHttp;
@@ -306,7 +306,7 @@ final class MockSteps
 
         @NotNull
         @Override
-        public AlchemyRequest.Step5<R> onSuccess(AlchemyRequest.OnSuccess<R> onSuccess)
+        public AlchemyRequestSteps.Step5<R> onSuccess(AlchemyRequestSteps.OnSuccess<R> onSuccess)
         {
             checkThat(onSuccess)
                     .usingMessage("callback cannot be null")
@@ -324,16 +324,16 @@ final class MockSteps
     }
 
     @StepMachineDesign(role = STEP)
-    static class MockStep5<R> implements AlchemyRequest.Step5<R>
+    static class MockStep5<R> implements AlchemyRequestSteps.Step5<R>
     {
 
         final MockAlchemyHttp mockAlchemyHttp;
-        final AlchemyRequest.OnSuccess<R> onSuccessCallback;
+        final AlchemyRequestSteps.OnSuccess<R> onSuccessCallback;
         final Class<R> expectedClass;
         final MockRequest request;
 
         MockStep5(MockAlchemyHttp mockAlchemyHttp,
-                  AlchemyRequest.OnSuccess<R> onSuccessCallback,
+                  AlchemyRequestSteps.OnSuccess<R> onSuccessCallback,
                   Class<R> expectedClass,
                   MockRequest request)
         {
@@ -347,7 +347,7 @@ final class MockSteps
         }
 
         @Override
-        public AlchemyRequest.Step6<R> onFailure(AlchemyRequest.OnFailure onFailureCallback)
+        public AlchemyRequestSteps.Step6<R> onFailure(AlchemyRequestSteps.OnFailure onFailureCallback)
         {
             checkThat(onFailureCallback)
                 .usingMessage("callback cannot be null")
@@ -362,18 +362,18 @@ final class MockSteps
 
     }
 
-    static class MockStep6<R> implements AlchemyRequest.Step6<R>
+    static class MockStep6<R> implements AlchemyRequestSteps.Step6<R>
     {
 
         final MockAlchemyHttp mockAlchemyHttp;
-        final AlchemyRequest.OnSuccess<R> onSuccessCallback;
-        final AlchemyRequest.OnFailure onFailureCallback;
+        final AlchemyRequestSteps.OnSuccess<R> onSuccessCallback;
+        final AlchemyRequestSteps.OnFailure onFailureCallback;
         final Class<R> expectedClass;
         final MockRequest request;
 
         public MockStep6(MockAlchemyHttp mockAlchemyHttp,
-                         AlchemyRequest.OnSuccess<R> onSuccessCallback,
-                         AlchemyRequest.OnFailure onFailureCallback,
+                         AlchemyRequestSteps.OnSuccess<R> onSuccessCallback,
+                         AlchemyRequestSteps.OnFailure onFailureCallback,
                          Class<R> expectedClass,
                          MockRequest request)
         {

--- a/src/main/java/tech/sirwellington/alchemy/http/mock/MockSteps.java
+++ b/src/main/java/tech/sirwellington/alchemy/http/mock/MockSteps.java
@@ -191,10 +191,10 @@ final class MockSteps
 
         @NotNull
         @Override
-        public AlchemyRequest.Step3 accept(String s, String... strings) throws IllegalArgumentException
+        public AlchemyRequest.Step3 accept(String first, String... others) throws IllegalArgumentException
         {
-            String tail = String.join(", ", strings);
-            String header = String.join(", ", s, tail);
+            String tail = String.join(", ", others);
+            String header = String.join(", ", first, tail);
 
             return this.usingHeader("Accept", header);
         }

--- a/src/test/java/tech/sirwellington/alchemy/http/mock/MockStepsTest.java
+++ b/src/test/java/tech/sirwellington/alchemy/http/mock/MockStepsTest.java
@@ -24,9 +24,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import tech.sirwellington.alchemy.http.AlchemyRequest;
-import tech.sirwellington.alchemy.http.AlchemyRequest.OnFailure;
-import tech.sirwellington.alchemy.http.AlchemyRequest.OnSuccess;
+import tech.sirwellington.alchemy.http.AlchemyRequestSteps;
+import tech.sirwellington.alchemy.http.AlchemyRequestSteps.OnFailure;
+import tech.sirwellington.alchemy.http.AlchemyRequestSteps.OnSuccess;
 import tech.sirwellington.alchemy.http.HttpResponse;
 import tech.sirwellington.alchemy.http.exceptions.AlchemyHttpException;
 import tech.sirwellington.alchemy.http.mock.MockSteps.*;
@@ -95,7 +95,7 @@ public class MockStepsTest
     {
         MockStep1 step1 = new MockStep1(mockHttp);
 
-        AlchemyRequest.Step3 get = step1.get();
+        AlchemyRequestSteps.Step3 get = step1.get();
         assertThat(get, notNullValue());
         assertThat(get, is(instanceOf(MockStep3.class)));
         MockStep3 mockStep3 = (MockStep3) get;
@@ -107,7 +107,7 @@ public class MockStepsTest
     {
         MockStep1 step1 = new MockStep1(mockHttp);
 
-        AlchemyRequest.Step2 post = step1.post();
+        AlchemyRequestSteps.Step2 post = step1.post();
         assertThat(post, notNullValue());
         assertThat(post, is(instanceOf(MockStep2.class)));
         MockStep2 mockStep2 = (MockStep2) post;
@@ -119,7 +119,7 @@ public class MockStepsTest
     {
         MockStep1 step1 = new MockStep1(mockHttp);
 
-        AlchemyRequest.Step2 put = step1.put();
+        AlchemyRequestSteps.Step2 put = step1.put();
         assertThat(put, notNullValue());
         assertThat(put, is(instanceOf(MockStep2.class)));
         MockStep2 mockStep2 = (MockStep2) put;
@@ -131,7 +131,7 @@ public class MockStepsTest
     {
         MockStep1 step1 = new MockStep1(mockHttp);
 
-        AlchemyRequest.Step2 delete = step1.delete();
+        AlchemyRequestSteps.Step2 delete = step1.delete();
         assertThat(delete, notNullValue());
         assertThat(delete, is(instanceOf(MockStep2.class)));
         MockStep2 mockStep2 = (MockStep2) delete;
@@ -154,7 +154,7 @@ public class MockStepsTest
     {
         MockStep2 step2 = new MockStep2(mockHttp, request);
 
-        AlchemyRequest.Step3 nothing = step2.nothing();
+        AlchemyRequestSteps.Step3 nothing = step2.nothing();
         assertThat(nothing, notNullValue());
         assertThat(nothing, is(instanceOf(MockStep3.class)));
 
@@ -169,7 +169,7 @@ public class MockStepsTest
     {
         MockStep2 step2 = new MockStep2(mockHttp, request);
 
-        AlchemyRequest.Step3 body = step2.body(date);
+        AlchemyRequestSteps.Step3 body = step2.body(date);
         assertThat(body, notNullValue());
         assertThat(body, is(instanceOf(MockStep3.class)));
 
@@ -195,7 +195,7 @@ public class MockStepsTest
         MockStep2 step2 = new MockStep2(mockHttp, request);
 
         String string = one(strings());
-        AlchemyRequest.Step3 body = step2.body(string);
+        AlchemyRequestSteps.Step3 body = step2.body(string);
         assertThat(body, notNullValue());
         assertThat(body, is(instanceOf(MockStep3.class)));
 
@@ -230,7 +230,7 @@ public class MockStepsTest
         List<Class<?>> classes = Arrays.asList(String.class, Date.class, Instant.class);
         Class<?> expected = classes.stream().findAny().get();
 
-        AlchemyRequest.Step4<?> expecting = step3.expecting(expected);
+        AlchemyRequestSteps.Step4<?> expecting = step3.expecting(expected);
         assertThat(expecting, notNullValue());
         assertThat(expecting, is(instanceOf(MockStep4.class)));
 
@@ -262,7 +262,7 @@ public class MockStepsTest
     {
         MockStep4<HttpResponse> step4 = new MockStep4<>(mockHttp, request, HttpResponse.class);
 
-        AlchemyRequest.Step5 response = step4.onSuccess(successCallback);
+        AlchemyRequestSteps.Step5 response = step4.onSuccess(successCallback);
 
         assertThat(response, notNullValue());
         assertThat(response, is(instanceOf(MockSteps.MockStep5.class)));
@@ -292,7 +292,7 @@ public class MockStepsTest
     {
 
         MockSteps.MockStep5<HttpResponse> instance = new MockSteps.MockStep5<>(mockHttp, successCallback, HttpResponse.class, request);
-        AlchemyRequest.Step6<HttpResponse> response = instance.onFailure(failureCallback);
+        AlchemyRequestSteps.Step6<HttpResponse> response = instance.onFailure(failureCallback);
         assertThat(response, notNullValue());
         assertThat(response, is(instanceOf(MockSteps.MockStep6.class)));
 
@@ -310,8 +310,8 @@ public class MockStepsTest
     {
         assertThrows(() -> new MockSteps.MockStep5<>(null, OnSuccess.Companion.getNO_OP(), Object.class, request));
         assertThrows(() -> new MockSteps.MockStep5<>(mockHttp, null, String.class, request));
-        assertThrows(() -> new MockSteps.MockStep5<>(mockHttp, AlchemyRequest.OnSuccess.INSTANCES.NO_OP, null, request));
-        assertThrows(() -> new MockSteps.MockStep5<>(mockHttp, AlchemyRequest.OnSuccess.INSTANCES.NO_OP, Object.class, null));
+        assertThrows(() -> new MockSteps.MockStep5<>(mockHttp, AlchemyRequestSteps.OnSuccess.INSTANCES.NO_OP, null, request));
+        assertThrows(() -> new MockSteps.MockStep5<>(mockHttp, AlchemyRequestSteps.OnSuccess.INSTANCES.NO_OP, Object.class, null));
 
         MockSteps.MockStep5<Object> instance = new MockSteps.MockStep5<>(mockHttp, OnSuccess.INSTANCES.NO_OP, Object.class, request);
         assertThrows(() -> instance.onFailure(null))

--- a/src/test/java/tech/sirwellington/alchemy/http/mock/MockStepsTest.java
+++ b/src/test/java/tech/sirwellington/alchemy/http/mock/MockStepsTest.java
@@ -308,12 +308,12 @@ public class MockStepsTest
     @Test
     public void testStep5WithBadArgs()
     {
-        assertThrows(() -> new MockSteps.MockStep5<>(null, AlchemyRequest.OnSuccess.NO_OP, String.class, request));
+        assertThrows(() -> new MockSteps.MockStep5<>(null, OnSuccess.Companion.getNO_OP(), Object.class, request));
         assertThrows(() -> new MockSteps.MockStep5<>(mockHttp, null, String.class, request));
-        assertThrows(() -> new MockSteps.MockStep5<>(mockHttp, AlchemyRequest.OnSuccess.NO_OP, null, request));
-        assertThrows(() -> new MockSteps.MockStep5<>(mockHttp, AlchemyRequest.OnSuccess.NO_OP, String.class, null));
+        assertThrows(() -> new MockSteps.MockStep5<>(mockHttp, AlchemyRequest.OnSuccess.INSTANCES.NO_OP, null, request));
+        assertThrows(() -> new MockSteps.MockStep5<>(mockHttp, AlchemyRequest.OnSuccess.INSTANCES.NO_OP, Object.class, null));
 
-        MockSteps.MockStep5<String> instance = new MockSteps.MockStep5<>(mockHttp, OnSuccess.NO_OP, String.class, request);
+        MockSteps.MockStep5<Object> instance = new MockSteps.MockStep5<>(mockHttp, OnSuccess.INSTANCES.NO_OP, Object.class, request);
         assertThrows(() -> instance.onFailure(null))
             .isInstanceOf(IllegalArgumentException.class);
 


### PR DESCRIPTION
Rewrites the entire Library in Kotlin, and drops usage of the Apache HTTP Client, in favor of the native `HTTPURLConnection` interface.
This makes the code compatible with the Android platform as well as the native JDK.